### PR TITLE
History fixes

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -1,12 +1,12 @@
 const Discord = require('discord.js');
 const {
-  getHistory, getGains, getLosses, addHistory,
+  getGains, getLosses, addHistory, getSortedHistory,
 } = require('./dbActions');
 const { getEarningsString, moneyString } = require('./utilities');
 
 // Commands
 const history = (message) => {
-  const userHistory = getHistory(message.author.id);
+  const userHistory = getSortedHistory(message.author.id);
   if (!userHistory.length) {
     message.channel.send('Sorry this user has no history, try gambling first!');
     return;

--- a/commands.js
+++ b/commands.js
@@ -76,7 +76,7 @@ const adminAddHistory = (message, args) => {
     message.channel.send(`Speak to me in a language I understand <@!${message.author.id}>!`);
     return;
   }
-  const [userId, amountChange, totalAmount, timestamp] = args;
+  const [userId, amountChange, totalAmount, snowflake] = args;
   if (!/\d{18}/.test(userId)) {
     message.channel.send(`Couldn't parse '${userId}' into a userId...`);
     return;
@@ -91,12 +91,8 @@ const adminAddHistory = (message, args) => {
     message.channel.send(`Couldn't parse the total '${totalAmount}' into a float...`);
     return;
   }
-  const ts = Number.parseInt(timestamp, 10);
-  if (Number.isNaN(ts) || ts < 1514764800000) { // 2018-01-01 00:00:00 UTC
-    message.channel.send(`Couldn't parse the timestamp '${timestamp}' into an Date...`);
-    return;
-  }
-  addHistory(userId, amountChange, totalAmount, ts);
+  const { timestamp } = Discord.Snowflake.deconstruct(snowflake);
+  addHistory(userId, changed, total, timestamp);
   message.channel.send('Added!');
 };
 

--- a/dbActions.js
+++ b/dbActions.js
@@ -27,6 +27,19 @@ const addHistory = (userId, change, total, timestamp) => {
 
 const getHistory = userId => getUser(userId).history;
 
+const getSortedHistory = (userId) => {
+  const history = getHistory(userId);
+  if (history.length === 0) {
+    return history;
+  }
+  const historyMap = new Map();
+  history.forEach(i => historyMap.set(i.timestamp, i));
+  const sortedHistory = [];
+  Array.from(historyMap.keys()).sort().forEach(id =>
+    sortedHistory.push(historyMap.get(id)));
+  return sortedHistory;
+};
+
 const getLosses = userId =>
   getHistory(userId).reduce((total, i) => {
     if (i.change < 0) {
@@ -46,5 +59,6 @@ const getGains = userId =>
 exports.getUser = getUser;
 exports.addHistory = addHistory;
 exports.getHistory = getHistory;
+exports.getSortedHistory = getSortedHistory;
 exports.getLosses = getLosses;
 exports.getGains = getGains;

--- a/dbActions.js
+++ b/dbActions.js
@@ -6,7 +6,7 @@ const db = low(adapter);
 db.defaults({ users: [] }).write();
 
 const createUser = userId => db.get('users').push({
-  id: userId, gains: 0, losses: 0, history: [],
+  id: userId, history: [],
 }).write();
 
 const getUser = (userId) => {
@@ -18,24 +18,30 @@ const getUser = (userId) => {
   return value;
 };
 
-const updateWinnings = (userId, change) => {
-  const user = db.get('users').find({ id: userId });
-  const userValues = user.value();
-  if (change < 0) user.assign({ losses: userValues.losses + Math.abs(change) }).write();
-  if (change > 0) user.assign({ gains: userValues.gains + change }).write();
-};
-
 const addHistory = (userId, change, total, timestamp) => {
   if (!userId || !change || !total || !timestamp) return;
   getUser(userId);
   db.get('users').find({ id: userId }).get('history').push({ timestamp, change, total })
     .write();
-  updateWinnings(userId, change);
 };
 
 const getHistory = userId => getUser(userId).history;
-const getLosses = userId => getUser(userId).losses;
-const getGains = userId => getUser(userId).gains;
+
+const getLosses = userId =>
+  getHistory(userId).reduce((total, i) => {
+    if (i.change < 0) {
+      return total + Math.abs(i.change);
+    }
+    return total;
+  }, 0);
+
+const getGains = userId =>
+  getHistory(userId).reduce((total, i) => {
+    if (i.change > 0) {
+      return total + i.change;
+    }
+    return total;
+  }, 0);
 
 exports.getUser = getUser;
 exports.addHistory = addHistory;


### PR DESCRIPTION
This PR makes a few changes:

* When adding entries have the admin post a message `Snowflake` instead of having them manually determine the JavaScript timestamp
* Stop storing the gains/losses in the database
  * This had somehow already gotten out of sync with the history entries 🤦‍♂️ 
* Return history sorted by timestamp